### PR TITLE
Add /recipes section

### DIFF
--- a/astro_site/package-lock.json
+++ b/astro_site/package-lock.json
@@ -1904,6 +1904,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2064,6 +2065,7 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.12.0.tgz",
       "integrity": "sha512-Oov5JsMFHuUmuO+Nx6plfv3nQNK1Xl/8CgLvR8lBhZTjYnraxhuPX5COVAzbom+YLgwaDfK7KBd8zOEopRf9mg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.12.2",
         "@astrojs/internal-helpers": "0.6.1",
@@ -5659,6 +5661,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.45.1.tgz",
       "integrity": "sha512-4iya7Jb76fVpQyLoiVpzUrsjQ12r3dM7fIVz+4NwoYvZOShknRmiv+iu9CClZml5ZLGb0XMcYLutK6w9tgxHDw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -5699,6 +5702,7 @@
       "integrity": "sha512-xCmtksBKd/jdJ9Bt9p7nPKiuqrlBMBuuGkQlkhZjjQk3Ty48lv93k5Dq6OPkKt4XwxDJ7tvlfrTa1MPA9bf+QA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -6423,6 +6427,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -6637,6 +6642,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/astro_site/src/content/config.ts
+++ b/astro_site/src/content/config.ts
@@ -23,7 +23,29 @@ const notes = defineCollection({
   }),
 });
 
+const recipes = defineCollection({
+  type: 'content',
+  schema: ({ image }) => z.object({
+    title: z.string(),
+    date: z.date(),
+    tags: z.array(z.string()).optional(),
+    featuredImage: z.union([image(), z.null()]).optional().default(null),
+    attribution: z.string().optional(),
+    equipment: z.array(z.string()),
+    ingredients: z.array(z.object({
+      name: z.string(),
+      amount: z.number(),
+      unit: z.string().nullable().optional(),
+      dish: z.string(),
+      dish_ml: z.number().optional(),
+      prep: z.string().optional(),
+    })),
+    steps: z.array(z.string()).default([]),
+  }),
+});
+
 export const collections = {
   posts,
   notes,
+  recipes,
 };

--- a/astro_site/src/content/recipes/al-pastor-marinade.md
+++ b/astro_site/src/content/recipes/al-pastor-marinade.md
@@ -1,0 +1,126 @@
+---
+title: "Al Pastor Marinade"
+date: 2026-04-23
+tags:
+  - mexican
+  - marinade
+  - pork
+equipment:
+  - Cast iron grill plate
+  - Kettle
+  - Heat-safe bowl, 500ml or larger
+  - Small plate for weighing chiles submerged
+  - Tongs
+  - Measuring cup, 150ml or larger
+  - Cutting board and sharp knife
+  - Citrus juicer
+  - Kitchen scale
+  - Blender
+  - Fine mesh sieve
+  - Rubber spatula
+  - Storage container with lid, 600ml or larger
+ingredients:
+  - name: dried ancho chiles
+    amount: 2
+    unit: null
+    dish: A
+    dish_ml: 40
+    prep: stems and seeds removed
+  - name: dried guajillo chiles
+    amount: 3
+    unit: null
+    dish: A
+    dish_ml: 30
+    prep: stems and seeds removed
+  - name: water
+    amount: 240
+    unit: ml
+    dish: B
+    prep: boiled
+  - name: chipotles in adobo
+    amount: 2
+    unit: null
+    dish: C
+    dish_ml: 30
+  - name: adobo sauce
+    amount: 15
+    unit: ml
+    dish: C
+  - name: fresh pineapple
+    amount: 80
+    unit: g
+    dish: D
+    prep: peeled, cored, in chunks
+  - name: garlic cloves
+    amount: 5
+    unit: null
+    dish: D
+    prep: peeled
+  - name: white onion
+    amount: 50
+    unit: g
+    dish: D
+    prep: rough chopped
+  - name: red Thai chile
+    amount: 1
+    unit: null
+    dish: D
+    prep: seeded and deveined
+  - name: orange
+    amount: 1
+    unit: null
+    dish: E
+    dish_ml: 80
+    prep: juiced, seeds caught
+  - name: white wine vinegar
+    amount: 30
+    unit: ml
+    dish: E
+  - name: smoked paprika
+    amount: 4
+    unit: g
+    dish: F
+  - name: ground cumin
+    amount: 2
+    unit: g
+    dish: F
+  - name: Mexican oregano
+    amount: 1
+    unit: g
+    dish: F
+  - name: ground black pepper
+    amount: 1
+    unit: g
+    dish: F
+  - name: ground cloves
+    amount: 0.25
+    unit: g
+    dish: F
+  - name: salt
+    amount: 9
+    unit: g
+    dish: F
+  - name: tomato paste
+    amount: 15
+    unit: g
+    dish: G
+  - name: brown sugar
+    amount: 12
+    unit: g
+    dish: G
+  - name: neutral oil
+    amount: 30
+    unit: ml
+    dish: H
+  - name: tejpat leaf
+    amount: 1
+    unit: null
+    dish: I
+steps:
+  - "Heat the cast iron grill plate over medium. Toast the ancho and guajillo chiles 30 seconds per side until fragrant and pliable — do not let them blacken. Remove from heat."
+  - "Bring the kettle to a boil. Pour boiling water over the toasted chiles in a heat-safe bowl, weight them down with a small plate to keep them submerged, and soak 20 minutes. Reserve 150ml of the soaking liquid before draining."
+  - "Tip the soaked chiles, chipotles plus adobo sauce, pineapple-garlic-onion-Thai-chile mix, orange juice and vinegar, the spice mix, tomato paste and brown sugar, and 120ml of the reserved soaking liquid into the blender. Blend on high until completely smooth, 60–90 seconds."
+  - "With the blender running, drizzle in the neutral oil to emulsify. Pour the marinade through a fine mesh sieve into the storage container, pressing solids with a rubber spatula to extract every drop."
+  - "Drop the tejpat leaf into the marinade and seal the container. Refrigerate at least 12 hours before adding pork (the flavors need time to marry)."
+  - "Add shaved pork shoulder no more than 2 hours before cooking. Set a timer the moment the pork hits the marinade — fresh pineapple's bromelain will turn shaved shoulder mushy past 2 hours."
+---

--- a/astro_site/src/content/recipes/al-pastor-tacos.md
+++ b/astro_site/src/content/recipes/al-pastor-tacos.md
@@ -1,0 +1,54 @@
+---
+title: "Al Pastor Tacos"
+date: 2026-04-23
+tags:
+  - mexican
+  - pork
+  - tacos
+equipment:
+  - Cast iron grill plate
+  - Tongs
+  - Cutting board and sharp knife
+  - Plate for resting cooked pork
+  - Plate for draining marinated pork
+  - Small serving bowls (for diced onion, charred pineapple)
+  - Small plate for lemon wedges
+  - Tortilla warmer or clean kitchen towel
+ingredients:
+  - name: shaved pork shoulder
+    amount: 580
+    unit: g
+    dish: A
+    prep: marinated for exactly 2 hours, then drained
+  - name: pineapple planks
+    amount: 5
+    unit: null
+    dish: B
+    dish_ml: 200
+    prep: cut ~1cm thick from remaining fresh pineapple
+  - name: white onion
+    amount: 80
+    unit: g
+    dish: C
+    prep: finely diced (~3mm)
+  - name: lemon
+    amount: 1
+    unit: null
+    dish: D
+    dish_ml: 60
+    prep: cut into 7 wedges
+  - name: corn tortillas
+    amount: 7
+    unit: null
+    dish: E
+  - name: chipotle salsa
+    amount: 60
+    unit: ml
+    dish: F
+steps:
+  - "Heat the cast iron grill plate over medium-high until smoking lightly."
+  - "Lay the pineapple planks flat on the grill plate and char ~2 minutes per side until dark grill marks appear and edges caramelize. Transfer to a plate, dice into ~1cm pieces, and tip into a small serving bowl."
+  - "Working in batches that fit in a single layer with space between pieces, lay the drained pork on the grill plate. Cook undisturbed ~2 minutes until deeply caramelized on the underside, flip, and cook another 1–2 minutes. Transfer each batch to the resting plate and repeat until all pork is cooked."
+  - "Warm the corn tortillas directly on the grill plate, ~15 seconds per side, stacking them in a tortilla warmer or wrapped towel as you go. Remove from heat — the grill plate is done."
+  - "Build each taco: a tortilla, a generous pile of pork, a spoonful of charred pineapple, a pinch of diced onion, and a drizzle of chipotle salsa. Squeeze a lemon wedge over and eat immediately."
+---

--- a/astro_site/src/content/recipes/beef-bourguignon.md
+++ b/astro_site/src/content/recipes/beef-bourguignon.md
@@ -1,0 +1,104 @@
+---
+title: "Beef Bourguignon"
+date: 2026-04-08
+tags:
+  - beef
+  - french
+  - braise
+equipment:
+  - Enameled Dutch oven
+  - Cutting board and knife
+  - Wooden spoon
+  - Tongs
+  - Slotted spoon
+  - Plate for resting browned beef
+ingredients:
+  - name: chuck steak
+    amount: 450
+    unit: g
+    dish: A
+    prep: cut into 3–4cm cubes, patted dry, salted lightly 30 min ahead
+  - name: block bacon
+    amount: 100
+    unit: g
+    dish: B
+    prep: cut into ~1cm lardons
+  - name: onion
+    amount: 1
+    unit: null
+    dish: C
+    dish_ml: 200
+    prep: medium-diced
+  - name: carrots
+    amount: 2
+    unit: null
+    dish: C
+    dish_ml: 240
+    prep: peeled, cut into 2cm chunks
+  - name: garlic cloves
+    amount: 4
+    unit: null
+    dish: D
+    prep: smashed and roughly chopped
+  - name: tomato paste
+    amount: 15
+    unit: g
+    dish: D
+  - name: flour
+    amount: 20
+    unit: g
+    dish: E
+  - name: red wine
+    amount: 375
+    unit: ml
+    dish: F
+  - name: beef broth
+    amount: 250
+    unit: ml
+    dish: G
+  - name: bay leaves
+    amount: 2
+    unit: null
+    dish: H
+  - name: dried thyme
+    amount: 2
+    unit: g
+    dish: H
+  - name: pearl onions
+    amount: 200
+    unit: g
+    dish: I
+    prep: blanched 60 seconds, ice-bathed, peeled
+  - name: mushrooms
+    amount: 200
+    unit: g
+    dish: J
+    prep: quartered if large
+  - name: butter
+    amount: 20
+    unit: g
+    dish: K
+  - name: potatoes
+    amount: 300
+    unit: g
+    dish: L
+    prep: peeled, cut into 3cm chunks
+  - name: salt
+    amount: 5
+    unit: g
+    dish: M
+  - name: black pepper
+    amount: 2
+    unit: g
+    dish: M
+steps:
+  - "Heat the Dutch oven over medium-high. Add the lardons and render until crisp and the fat has pooled, about 6 minutes. Lift the lardons out with a slotted spoon to a plate, leaving the fat behind."
+  - "Working in batches that don't crowd the pot, brown the beef cubes hard on all sides in the bacon fat — 3 minutes per side, deeply caramelized. Move browned beef to the lardon plate."
+  - "Drop the heat to medium. Add the onion and carrots and cook 6–8 minutes until the onion is translucent and starting to color. Stir in the garlic and tomato paste; cook 1 minute until the paste darkens."
+  - "Sprinkle the flour over the vegetables and stir 2 minutes — this thickens the braise and removes the raw flour taste."
+  - "Pour in the red wine, scraping the fond off the bottom of the pot. Let it simmer hard for 3 minutes to cook off the alcohol's harshness."
+  - "Return the beef and lardons to the pot, add the broth, bay leaves, and thyme, and salt lightly. Bring to a bare simmer, lid on, and braise on low for 2 hours — keep it just barely bubbling. The pot should not be boiling."
+  - "Meanwhile, in a separate pan, sauté the mushrooms in butter until deeply browned. Set aside until the last 30 minutes."
+  - "After 2 hours, add the pearl onions, potatoes, and sautéed mushrooms. Continue at a bare simmer 30–40 minutes more, until the potatoes are tender and the meat falls apart at a fork press."
+  - "Pull out the bay leaves. Taste and adjust with salt and pepper. Rest off heat 10 minutes before serving — the sauce thickens further as it sits."
+---

--- a/astro_site/src/content/recipes/chicken-and-stuffing-pot-pie.md
+++ b/astro_site/src/content/recipes/chicken-and-stuffing-pot-pie.md
@@ -1,0 +1,72 @@
+---
+title: "Chicken and Stuffing Pot Pie"
+date: 2026-04-19
+tags:
+  - chicken
+  - comfort
+  - american
+attribution: "Built from leftover Boston Market-style baked chicken thighs and a box of Stovetop"
+equipment:
+  - Non-stick grill pan or saucepan (for gravy)
+  - Whisk
+  - Wooden spoon
+  - 1.5L baking dish
+  - Two forks (for shredding)
+  - Combo microwave/oven
+ingredients:
+  - name: cooked chicken thighs
+    amount: 300
+    unit: g
+    dish: A
+    prep: shredded with two forks
+  - name: frozen mixed vegetables
+    amount: 150
+    unit: g
+    dish: B
+  - name: frozen mirepoix
+    amount: 150
+    unit: g
+    dish: C
+    prep: microwave-thawed and patted dry for better browning
+  - name: butter
+    amount: 20
+    unit: g
+    dish: D
+  - name: flour
+    amount: 15
+    unit: g
+    dish: E
+  - name: hot water
+    amount: 260
+    unit: ml
+    dish: F
+  - name: bouillon cube
+    amount: 1
+    unit: null
+    dish: F
+    prep: dissolved in the hot water
+  - name: black pepper
+    amount: 1
+    unit: g
+    dish: G
+  - name: Stovetop stuffing mix
+    amount: 170
+    unit: g
+    dish: H
+  - name: butter for stuffing
+    amount: 30
+    unit: g
+    dish: I
+  - name: hot water for stuffing
+    amount: 240
+    unit: ml
+    dish: I
+steps:
+  - "Preheat the oven to 190°C and lightly grease the baking dish."
+  - "Melt the butter in the grill pan over medium heat. Add the thawed mirepoix and cook 6–7 minutes, stirring occasionally, until the onion is translucent and edges color slightly."
+  - "Sprinkle the flour over the mirepoix and stir for 1–2 minutes until it smells nutty and the raw flour taste is gone."
+  - "Whisk the bouillon water in gradually, scraping the pan to lift fond. Bring to a simmer and cook 2–3 minutes until it's a loose gravy. Season with black pepper."
+  - "Stir in the shredded chicken and frozen mixed vegetables; the veg can go in straight from frozen. Tip the filling into the baking dish."
+  - "Make the Stovetop per the box: bring the hot water and butter to a boil in the same pan, stir in the stuffing mix, cover and rest 5 minutes, then fluff. Spread the stuffing across the top of the filling — don't pack it down. Remove from heat — the grill pan is done."
+  - "Bake 20–25 minutes until the stuffing is golden and the gravy is bubbling at the edges. Rest 5 minutes before serving."
+---

--- a/astro_site/src/content/recipes/chicken-italian-dressing-wraps.md
+++ b/astro_site/src/content/recipes/chicken-italian-dressing-wraps.md
@@ -1,0 +1,85 @@
+---
+title: "Chicken Italian Dressing Wraps"
+date: 2026-04-21
+tags:
+  - chicken
+  - wraps
+  - quick
+equipment:
+  - Non-stick grill pan
+  - Cutting board and knife
+  - Microplane
+  - Citrus juicer
+  - Spatula or tongs
+  - Heavy pan or lid for pressing
+ingredients:
+  - name: cooked chicken breast
+    amount: 220
+    unit: g
+    dish: A
+    prep: shredded or sliced into strips
+  - name: Italian dressing
+    amount: 75
+    unit: ml
+    dish: A
+  - name: garlic
+    amount: 2
+    unit: null
+    dish: A
+    prep: grated on a microplane
+  - name: lemon
+    amount: 0.5
+    unit: null
+    dish: A
+    dish_ml: 30
+    prep: juiced (~15ml)
+  - name: parmesan
+    amount: 25
+    unit: g
+    dish: B
+    prep: finely grated
+  - name: mixed cheese
+    amount: 80
+    unit: g
+    dish: C
+  - name: butter
+    amount: 20
+    unit: g
+    dish: D
+  - name: cherry tomatoes
+    amount: 150
+    unit: g
+    dish: E
+    prep: halved
+  - name: pickled red onion
+    amount: 60
+    unit: g
+    dish: E
+    prep: drained
+  - name: pre-cut romaine
+    amount: 120
+    unit: g
+    dish: F
+  - name: 8 inch flour tortillas
+    amount: 4
+    unit: null
+    dish: G
+  - name: Italian dressing for assembly drizzle
+    amount: 30
+    unit: ml
+    dish: H
+  - name: dried oregano
+    amount: 1
+    unit: g
+    dish: I
+  - name: black pepper
+    amount: 1
+    unit: g
+    dish: I
+steps:
+  - "Combine the shredded chicken with the Italian dressing, grated garlic, and lemon juice. Toss well and let it sit 10–15 minutes — this is your hands-off window for prepping the rest."
+  - "Halve the cherry tomatoes and combine with the drained pickled red onion in a bowl."
+  - "Build each wrap on a tortilla: a layer of romaine, a quarter of the marinated chicken, a quarter of the tomato-onion mix, a sprinkle of parmesan, a sprinkle of mixed cheese, a light drizzle of Italian dressing, and a pinch of oregano and black pepper. Roll tightly seam-side down."
+  - "Melt the butter in the grill pan over medium heat. Lay the wraps seam-side down, weight with a heavy pan or lid, and press 2–3 minutes until golden. Flip, press the other side 2 minutes more."
+  - "Slice each wrap on the bias and serve immediately with macaroni salad on the side."
+---

--- a/astro_site/src/content/recipes/chuck-steak-with-red-wine-pan-sauce.md
+++ b/astro_site/src/content/recipes/chuck-steak-with-red-wine-pan-sauce.md
@@ -1,0 +1,79 @@
+---
+title: "Chuck Steak with Red Wine Pan Sauce"
+date: 2026-04-15
+tags:
+  - beef
+  - quick
+equipment:
+  - Oval enameled Dutch oven
+  - Cutting board and knife
+  - Tongs
+  - Wooden spoon
+  - Plate for resting steak
+  - Foil for tenting
+  - Microplane
+ingredients:
+  - name: chuck steak
+    amount: 550
+    unit: g
+    dish: A
+    prep: patted bone-dry, salted on both sides 40 min ahead, room temperature
+  - name: neutral oil
+    amount: 15
+    unit: ml
+    dish: B
+  - name: butter for searing
+    amount: 30
+    unit: g
+    dish: C
+  - name: garlic cloves
+    amount: 4
+    unit: null
+    dish: C
+    prep: smashed, skin on
+  - name: fresh rosemary or thyme
+    amount: 2
+    unit: g
+    dish: C
+  - name: shallot
+    amount: 1
+    unit: null
+    dish: D
+    dish_ml: 60
+    prep: minced
+  - name: red wine
+    amount: 120
+    unit: ml
+    dish: E
+  - name: beef broth
+    amount: 120
+    unit: ml
+    dish: F
+  - name: cold butter for finishing
+    amount: 20
+    unit: g
+    dish: G
+    prep: cubed
+  - name: lemon juice
+    amount: 5
+    unit: ml
+    dish: H
+  - name: black pepper
+    amount: 2
+    unit: g
+    dish: I
+  - name: flaky salt
+    amount: 1
+    unit: g
+    dish: J
+steps:
+  - "Pat the steak completely dry — this is the difference between sear and steam. Crack pepper over both sides."
+  - "Heat the Dutch oven over high until it just barely smokes. Add the neutral oil, swirl, then lay the steak in. Don't touch it for 4 minutes — let the crust form."
+  - "Flip the steak. Add the searing butter, smashed garlic, and rosemary or thyme. Tilt the pot toward you and baste the steak with the foaming butter for 3–4 minutes, until the second side is deeply browned and the internal temp reads 52°C for medium-rare."
+  - "Move the steak to a plate, tent loosely with foil, and rest 8 minutes. Discard the spent garlic and herbs from the pot."
+  - "Drop the heat to medium. Add the minced shallot to the fond and cook 60 seconds until softened."
+  - "Pour in the red wine, scraping every bit of fond off the bottom. Reduce hard for 2 minutes until it's thickened to syrup."
+  - "Add the beef broth and reduce another 2–3 minutes until it coats the back of a spoon. Pull off the heat."
+  - "Whisk in the cold butter cubes one at a time, swirling the pot rather than stirring — this emulsifies the sauce. Finish with the lemon juice. Done with the Dutch oven."
+  - "Slice the steak against the grain on the bias. Pour any plate juices into the sauce, plate the slices over leftover mashed potatoes, spoon the sauce generously over the meat, and finish with flaky salt."
+---

--- a/astro_site/src/content/recipes/coq-au-vin-stew.md
+++ b/astro_site/src/content/recipes/coq-au-vin-stew.md
@@ -1,0 +1,109 @@
+---
+title: "Coq au Vin Stew"
+date: 2026-04-05
+tags:
+  - chicken
+  - french
+  - braise
+attribution: "Built on leftover beef bourguignon braising liquid"
+equipment:
+  - Enameled Dutch oven
+  - Cutting board and knife
+  - Wooden spoon
+  - Tongs
+  - Slotted spoon
+  - Plate for resting browned chicken
+ingredients:
+  - name: bone-in skin-on chicken thighs
+    amount: 1000
+    unit: g
+    dish: A
+    prep: patted dry, salted lightly 30 min ahead
+  - name: chicken wing tips
+    amount: 200
+    unit: g
+    dish: A
+    prep: rinsed and patted dry
+  - name: block bacon
+    amount: 100
+    unit: g
+    dish: B
+    prep: cut into ~1cm lardons
+  - name: carrots
+    amount: 3
+    unit: null
+    dish: C
+    dish_ml: 360
+    prep: peeled, cut into 3cm chunks
+  - name: celery
+    amount: 2
+    unit: null
+    dish: C
+    dish_ml: 100
+    prep: cut into 3cm chunks
+  - name: parsnip
+    amount: 1
+    unit: null
+    dish: C
+    dish_ml: 200
+    prep: peeled, cut into 3cm chunks
+  - name: turnip
+    amount: 1
+    unit: null
+    dish: C
+    dish_ml: 200
+    prep: peeled, cut into 3cm chunks
+  - name: garlic cloves
+    amount: 4
+    unit: null
+    dish: D
+    prep: smashed and roughly chopped
+  - name: tomato paste
+    amount: 15
+    unit: g
+    dish: D
+  - name: leftover beef bourguignon braising liquid
+    amount: 750
+    unit: ml
+    dish: E
+  - name: bay leaves
+    amount: 2
+    unit: null
+    dish: F
+  - name: dried thyme
+    amount: 2
+    unit: g
+    dish: F
+  - name: pearl onions
+    amount: 200
+    unit: g
+    dish: G
+    prep: blanched 60 seconds, ice-bathed, peeled
+  - name: mushrooms
+    amount: 200
+    unit: g
+    dish: H
+    prep: quartered if large
+  - name: butter
+    amount: 20
+    unit: g
+    dish: I
+  - name: salt
+    amount: 5
+    unit: g
+    dish: J
+  - name: black pepper
+    amount: 2
+    unit: g
+    dish: J
+steps:
+  - "Heat the Dutch oven over medium-high. Render the lardons until crisp and the fat has pooled, about 6 minutes. Lift the lardons out with a slotted spoon to a plate, leaving the fat behind."
+  - "Working skin-side down, brown the chicken thighs and wing tips hard in the bacon fat — 5 minutes for deeply caramelized skin, then 2 minutes on the meat side. Move to the lardon plate."
+  - "Drop the heat to medium. Add the carrots, celery, parsnip, and turnip and cook 6–8 minutes until edges color slightly. Stir in the garlic and tomato paste; cook 1 minute until the paste darkens."
+  - "Pour in the bourguignon braising liquid, scraping fond off the bottom. Bring to a bare simmer."
+  - "Return the chicken, wing tips, and lardons to the pot. Add the bay leaves and thyme. Lid on, simmer on low for 90 minutes — the wing tips give up their collagen and the thighs braise to falling apart."
+  - "Meanwhile, sauté the mushrooms in butter in a separate pan until deeply browned. Set aside."
+  - "After 90 minutes, lift the chicken thighs out with tongs. Pull the meat off the bone and shred — it should fall apart. Discard skin if you like, or chop it back in."
+  - "Fish out and discard the wing tips and bay leaves. Return the shredded meat to the pot with the pearl onions and sautéed mushrooms."
+  - "Simmer uncovered 20–30 minutes more to reduce and thicken — you want a true stew consistency, not a thin sauce. Taste and adjust salt and pepper. Rest off heat 10 minutes before serving."
+---

--- a/astro_site/src/content/recipes/cream-of-mushroom-smothered-chicken-breast.md
+++ b/astro_site/src/content/recipes/cream-of-mushroom-smothered-chicken-breast.md
@@ -1,0 +1,77 @@
+---
+title: "Cream of Mushroom Smothered Chicken Breast"
+date: 2026-01-28
+tags:
+  - chicken
+  - comfort
+  - american
+equipment:
+  - Sheet pan
+  - Combo microwave/oven
+  - Enameled Dutch oven (small) for carrots
+  - Wooden spoon
+  - Tongs
+ingredients:
+  - name: chicken tenderloins
+    amount: 400
+    unit: g
+    dish: A
+    prep: patted dry
+  - name: salt for chicken
+    amount: 3
+    unit: g
+    dish: B
+  - name: black pepper
+    amount: 1
+    unit: g
+    dish: B
+  - name: garlic powder
+    amount: 2
+    unit: g
+    dish: B
+  - name: paprika
+    amount: 2
+    unit: g
+    dish: B
+  - name: cream of mushroom soup
+    amount: 290
+    unit: g
+    dish: C
+  - name: frozen green beans
+    amount: 300
+    unit: g
+    dish: D
+  - name: olive oil for green beans
+    amount: 15
+    unit: ml
+    dish: E
+  - name: salt for green beans
+    amount: 2
+    unit: g
+    dish: F
+  - name: carrots
+    amount: 4
+    unit: null
+    dish: G
+    dish_ml: 480
+    prep: peeled, cut into 1cm coins
+  - name: butter for carrots
+    amount: 30
+    unit: g
+    dish: H
+  - name: salt for carrots
+    amount: 1
+    unit: g
+    dish: I
+  - name: honey
+    amount: 45
+    unit: g
+    dish: J
+steps:
+  - "Preheat the oven to 200°C."
+  - "Season the chicken tenderloins with the spice blend. Toss the frozen green beans with the olive oil and salt. Spread both on the sheet pan in a single layer, keeping them on opposite sides — chicken on one side, beans on the other."
+  - "Spoon the cream of mushroom soup over the chicken to smother. Roast 18–22 minutes until the chicken hits 70°C internal and the green beans have crisp edges."
+  - "Meanwhile, melt the butter in the small Dutch oven over medium heat. Add the carrots and salt; stir to coat. Lid on, cook 15–20 minutes, stirring occasionally and adding a splash of water if they look dry, until fork-tender."
+  - "When the carrots are tender, remove the lid, drizzle the honey over them, and toss to coat. Cook 2–3 minutes uncovered until the honey gets sticky and glazes the carrots. Remove from heat — the small Dutch oven is done."
+  - "Pull the sheet pan from the oven. Plate the smothered chicken with green beans and honey-glazed carrots alongside."
+---

--- a/astro_site/src/content/recipes/elote-en-vaso.md
+++ b/astro_site/src/content/recipes/elote-en-vaso.md
@@ -1,0 +1,48 @@
+---
+title: "Elote en Vaso"
+date: 2026-04-23
+tags:
+  - mexican
+  - corn
+  - side
+equipment:
+  - Wok
+  - Colander
+  - Paper towels
+  - Microplane
+  - Wooden spoon
+  - Serving cups
+ingredients:
+  - name: canned whole kernel corn
+    amount: 380
+    unit: g
+    dish: A
+    prep: drained well, patted dry on paper towels (drained weight ≈ 260g)
+  - name: unsalted butter
+    amount: 15
+    unit: g
+    dish: B
+  - name: kewpie mayonnaise
+    amount: 30
+    unit: g
+    dish: C
+  - name: lime juice
+    amount: 15
+    unit: ml
+    dish: C
+    prep: freshly squeezed
+  - name: chili powder
+    amount: 2
+    unit: g
+    dish: D
+  - name: finely grated parmesan
+    amount: 20
+    unit: g
+    dish: E
+steps:
+  - "Set the wok over medium heat — your stove runs hot, stay here. Add butter and let it foam, about 30 seconds."
+  - "Add the drained corn in a single layer. Leave it alone for 2.5 minutes so one side develops golden char — do not stir."
+  - "Toss the corn, then keep cooking until kernels are dry with golden-brown spots throughout, about another 2 minutes. Remove from heat — the wok is done."
+  - "Transfer the hot corn to serving cups. Pour in the kewpie-lime mixture and stir until every kernel is coated."
+  - "Scatter parmesan over the top — residual heat softens it. Dust the chili powder evenly over that. Apply the cheese and chili separately rather than pre-mixing: different particle sizes settle unevenly and you get chili hot spots. Serve warm."
+---

--- a/astro_site/src/content/recipes/hamburger-slumgullion.md
+++ b/astro_site/src/content/recipes/hamburger-slumgullion.md
@@ -1,0 +1,60 @@
+---
+title: "Slumgullion"
+date: 2026-01-01
+tags:
+  - heritage
+  - beef
+  - comfort
+attribution: "Approximated from memory of Grandma's. To the Bros."
+equipment:
+  - Enameled Dutch oven
+  - Wooden spoon
+  - Small saucepan with tight lid (for rice)
+  - Strainer (Optional)
+ingredients:
+  - name: ground beef
+    amount: 500
+    unit: g
+    dish: In its Package
+  - name: stewed tomatoes (Grandma's, thawed)
+    amount: 1000
+    unit: g
+    dish: In its Jar
+    prep: thawed overnight in the fridge
+  - name: salt
+    amount: 4
+    unit: g
+    dish: A
+  - name: black pepper
+    amount: 2
+    unit: g
+    dish: A
+  - name: white rice
+    amount: 360
+    unit: g
+    dish: B
+    prep: rinsed until water runs clear
+  - name: water for rice
+    amount: 540
+    unit: ml
+    dish: C
+  - name: white sandwich bread
+    amount: 4
+    unit: null
+    dish: D
+    dish_ml: 400
+  - name: butter for bread
+    amount: 40
+    unit: g
+    dish: E
+    prep: room temperature, soft enough to spread
+steps:
+  - "Start the rice. Combine rinsed rice and water in the saucepan, bring to a boil, drop to lowest heat, lid on tight, cook 18 minutes, then rest off heat 10 minutes. Done with the saucepan."
+  - "Meanwhile, heat the Dutch oven over medium-high. Add the ground beef and break it up with the wooden spoon. Cook 8–10 minutes until browned and most liquid has cooked off."
+  - "Strain out rendered beef fat, then return beef to dutch oven. Done with the Strainer."
+  - "Pour in the thawed stewed tomatoes, scraping any fond off the bottom of the pot. Stir in salt and pepper."
+  - "Drop the heat to low and simmer uncovered for 30 minutes, stirring every 5 minutes or so. The mixture should thicken to a loose stew — coats the spoon but still pours."
+  - "Taste and adjust salt and pepper. Done with the Dutch oven."
+  - "Spread butter generously across one side of each slice of bread — do not toast. The whole point is the soft cold bread against the hot stew."
+  - "Plate over rice. Serve the buttered bread on the side. If you have ginger brandy, raise a glass: \"To the Bros.\""
+---

--- a/astro_site/src/content/recipes/honey-glazed-carrots.md
+++ b/astro_site/src/content/recipes/honey-glazed-carrots.md
@@ -1,0 +1,35 @@
+---
+title: "Honey Glazed Carrots"
+date: 2025-11-14
+tags:
+  - side
+  - vegetable
+equipment:
+  - Enameled Dutch oven with lid
+  - Wooden spoon
+ingredients:
+  - name: carrots
+    amount: 4
+    unit: null
+    dish: A
+    dish_ml: 480
+    prep: peeled, cut into 1cm coins or batons
+  - name: butter
+    amount: 30
+    unit: g
+    dish: B
+  - name: salt
+    amount: 1
+    unit: g
+    dish: C
+  - name: honey
+    amount: 45
+    unit: g
+    dish: D
+steps:
+  - "Melt the butter in the Dutch oven over medium heat."
+  - "Add the carrots and salt; stir to coat in butter."
+  - "Cover with the lid and cook 15–20 minutes, stirring occasionally and adding a splash of water if the pot looks dry, until the carrots are fork-tender."
+  - "Remove the lid, drizzle the honey over the carrots, and toss to coat."
+  - "Cook 2–3 minutes uncovered until the honey reduces to a sticky glaze. Remove from heat — the Dutch oven is done."
+---

--- a/astro_site/src/content/recipes/lazy-winter-stewed-tomatoes.md
+++ b/astro_site/src/content/recipes/lazy-winter-stewed-tomatoes.md
@@ -1,0 +1,51 @@
+---
+title: "Lazy Winter Stewed Tomatoes"
+date: 2026-04-26
+tags:
+  - freezer
+  - vegetarian
+  - make-ahead
+attribution: "Adapted from my grandma's recipe"
+equipment:
+  - Enameled dutch oven
+  - Heat diffuser
+  - Cutting board and knife
+  - Freezer-safe containers
+ingredients:
+  - name: canned diced tomatoes
+    amount: 800
+    unit: g
+    dish: In Their Cans
+  - name: onion
+    amount: 100
+    unit: g
+    dish: A
+    prep: diced
+  - name: celery
+    amount: 50
+    unit: g
+    dish: A
+    prep: diced
+  - name: green pepper
+    amount: 50
+    unit: g
+    dish: A
+    prep: diced
+  - name: bird's eye chili
+    amount: 0.5
+    unit: null
+    dish: A
+    prep: thinly sliced
+  - name: salt
+    amount: 3
+    unit: g
+    dish: B
+  - name: black pepper
+    amount: 1
+    unit: g
+    dish: B
+steps:
+  - Combine everything in a dutch oven and bring to a simmer over medium heat.
+  - Drop to low (use the diffuser) and cook uncovered for 60–90 minutes, stirring occasionally, until the vegetables are tender and the liquid has thickened slightly. Remove from heat — the dutch oven is done.
+  - Cool to room temperature, then portion into freezer containers.
+---

--- a/astro_site/src/content/recipes/may-queen-mashed-potatoes.md
+++ b/astro_site/src/content/recipes/may-queen-mashed-potatoes.md
@@ -1,0 +1,41 @@
+---
+title: "May Queen Mashed Potatoes"
+date: 2026-04-08
+tags:
+  - side
+  - potatoes
+equipment:
+  - Large pot with lid
+  - Colander
+  - Potato masher
+  - Wooden spoon
+ingredients:
+  - name: May Queen potatoes
+    amount: 680
+    unit: g
+    dish: A
+    prep: peeled and quartered
+  - name: butter
+    amount: 45
+    unit: g
+    dish: B
+    prep: cubed, room temperature
+  - name: milk
+    amount: 80
+    unit: ml
+    dish: C
+    prep: warmed
+  - name: salt
+    amount: 4
+    unit: g
+    dish: D
+  - name: black pepper
+    amount: 1
+    unit: g
+    dish: D
+steps:
+  - "Cover the potatoes with cold water in a large pot, salt the water generously, and bring to a boil. Simmer 20 minutes until a knife slides through with no resistance."
+  - "Drain the potatoes in the colander. Return them to the hot pot on low heat for 1 minute to steam off excess moisture — this is the difference between fluffy and gluey."
+  - "Mash the potatoes with the butter until smooth. Stir in the warm milk a splash at a time until you hit the consistency you want."
+  - "Season with salt and pepper, taste, and adjust. Serve immediately."
+---

--- a/astro_site/src/content/recipes/paprika-rubbed-roast-chicken-breast.md
+++ b/astro_site/src/content/recipes/paprika-rubbed-roast-chicken-breast.md
@@ -1,0 +1,77 @@
+---
+title: "Paprika-Rubbed Roast Chicken Breast with Pan Sauce"
+date: 2026-01-06
+tags:
+  - chicken
+  - quick
+equipment:
+  - Cast iron grill plate or non-stick grill pan
+  - Combo microwave/oven
+  - Tongs
+  - Plate for resting
+  - Foil for tenting
+  - Whisk
+  - Cutting board and knife
+ingredients:
+  - name: boneless skin-on chicken breasts
+    amount: 2
+    unit: null
+    dish: A
+    prep: patted completely dry, room temperature
+  - name: paprika
+    amount: 7
+    unit: g
+    dish: B
+  - name: garlic powder
+    amount: 3
+    unit: g
+    dish: B
+  - name: onion powder
+    amount: 2
+    unit: g
+    dish: B
+  - name: salt
+    amount: 3
+    unit: g
+    dish: B
+  - name: black pepper
+    amount: 1
+    unit: g
+    dish: B
+  - name: neutral oil
+    amount: 15
+    unit: ml
+    dish: C
+  - name: shallot
+    amount: 1
+    unit: null
+    dish: D
+    dish_ml: 60
+    prep: minced
+  - name: white wine
+    amount: 120
+    unit: ml
+    dish: E
+  - name: chicken stock
+    amount: 120
+    unit: ml
+    dish: F
+  - name: cold butter
+    amount: 15
+    unit: g
+    dish: G
+    prep: cubed
+  - name: lemon juice
+    amount: 5
+    unit: ml
+    dish: H
+steps:
+  - "Preheat the oven to 220°C."
+  - "Mix the paprika, garlic powder, onion powder, salt, and pepper. Rub the blend generously over both sides and under the skin of each breast. Let them sit at room temperature for 20–30 minutes."
+  - "Heat the grill pan over medium-high with the neutral oil until it shimmers. Lay the breasts skin-side down and don't touch them for 4–5 minutes — wait for the skin to release on its own when it's deeply golden."
+  - "Flip the breasts and immediately transfer the pan to the oven. Roast 12–15 minutes until internal temp reads 65–68°C. Pull out and rest tented with foil on a plate for 5 minutes — they'll carry over to 70°C."
+  - "Return the pan to medium heat (mind the hot handle). Add the minced shallot to the drippings and cook 60 seconds."
+  - "Pour in the white wine, scraping fond off the bottom. Reduce by half, then add the stock. Simmer 3–4 minutes until it coats the back of a spoon."
+  - "Pull off the heat and whisk in the cold butter cubes one at a time, then the lemon juice. Taste and adjust salt. Done with the grill pan."
+  - "Slice each breast on the bias and pour the sauce generously over the top."
+---

--- a/astro_site/src/content/recipes/pesto-chicken-personal-pizzas.md
+++ b/astro_site/src/content/recipes/pesto-chicken-personal-pizzas.md
@@ -1,0 +1,80 @@
+---
+title: "Pesto Chicken Personal Pizzas"
+date: 2025-09-27
+tags:
+  - chicken
+  - pizza
+  - quick
+equipment:
+  - Sheet pan
+  - Combo microwave/oven
+  - Mixing bowl
+  - Spoon
+ingredients:
+  - name: par-baked personal pizza doughs
+    amount: 2
+    unit: null
+    dish: A
+    dish_ml: 600
+  - name: cooked shredded chicken
+    amount: 160
+    unit: g
+    dish: B
+  - name: basil pesto for chicken
+    amount: 45
+    unit: g
+    dish: B
+  - name: garlic powder for chicken
+    amount: 2
+    unit: g
+    dish: C
+  - name: smoked paprika
+    amount: 1
+    unit: g
+    dish: C
+  - name: red pepper flakes
+    amount: 1
+    unit: g
+    dish: C
+  - name: black pepper
+    amount: 1
+    unit: g
+    dish: C
+  - name: basil pesto for base
+    amount: 30
+    unit: g
+    dish: D
+  - name: dried oregano
+    amount: 1
+    unit: g
+    dish: E
+  - name: garlic powder for base
+    amount: 1
+    unit: g
+    dish: E
+  - name: shredded mozzarella
+    amount: 120
+    unit: g
+    dish: F
+  - name: cherry tomatoes
+    amount: 100
+    unit: g
+    dish: G
+    prep: halved
+  - name: parmesan
+    amount: 15
+    unit: g
+    dish: H
+    prep: finely grated
+  - name: pesto for finishing drizzle
+    amount: 15
+    unit: g
+    dish: I
+steps:
+  - "Preheat the oven to 230°C."
+  - "Combine the shredded chicken with the pesto and the chicken seasoning blend. Stir to coat every shred."
+  - "Place the par-baked doughs on the sheet pan. Spread the base pesto thinly across each one, then dust with the oregano-garlic powder blend."
+  - "Divide the seasoned chicken between the two pizzas. Top with mozzarella, then scatter the halved cherry tomatoes across."
+  - "Bake 12–15 minutes until the crust edges are golden and the cheese is bubbly and lightly browned in spots. Done with the oven."
+  - "Let the pizzas cool 2–3 minutes, then dust with the parmesan and drizzle the finishing pesto over the top. Slice and serve."
+---

--- a/astro_site/src/content/recipes/sakamushi-asari-with-garlic-bread-and-romaine-salad.md
+++ b/astro_site/src/content/recipes/sakamushi-asari-with-garlic-bread-and-romaine-salad.md
@@ -1,0 +1,109 @@
+---
+title: "Sakamushi Asari with Garlic Bread and Romaine Salad"
+date: 2026-04-21
+tags:
+  - seafood
+  - japanese
+equipment:
+  - Enameled Dutch oven with lid
+  - Fish grill or non-stick grill pan lined with foil
+  - Slotted spoon
+  - Cutting board and knife
+  - Microplane
+  - Citrus juicer
+  - Deep serving bowl for clams
+  - Salad plate
+ingredients:
+  - name: asari clams
+    amount: 600
+    unit: g
+    dish: A
+    prep: purged and triaged (any open or cracked clams discarded)
+  - name: butter
+    amount: 45
+    unit: g
+    dish: B
+    prep: cubed
+  - name: garlic
+    amount: 12
+    unit: g
+    dish: B
+    prep: minced
+  - name: red pepper flakes
+    amount: 1
+    unit: g
+    dish: B
+  - name: sake
+    amount: 120
+    unit: ml
+    dish: C
+  - name: soy sauce
+    amount: 5
+    unit: ml
+    dish: C
+  - name: lemon
+    amount: 1
+    unit: null
+    dish: D
+    dish_ml: 60
+    prep: zested, then halved — one half juiced (~15ml), the other cut into 4 wedges
+  - name: scallions
+    amount: 2
+    unit: null
+    dish: E
+    dish_ml: 30
+    prep: thinly sliced
+  - name: romaine hearts
+    amount: 140
+    unit: g
+    dish: F
+    prep: hand-torn
+  - name: Italian dressing
+    amount: 25
+    unit: ml
+    dish: F
+  - name: mikkusu cheese
+    amount: 5
+    unit: g
+    dish: F
+  - name: garlic bread loaf
+    amount: 1
+    unit: null
+    dish: G
+    prep: split vertically through the middle
+  - name: olive oil
+    amount: 15
+    unit: ml
+    dish: H
+  - name: garlic powder
+    amount: 1
+    unit: g
+    dish: H
+  - name: dried oregano
+    amount: 0.5
+    unit: g
+    dish: H
+  - name: raw garlic clove
+    amount: 1
+    unit: null
+    dish: I
+    prep: halved across the equator
+  - name: grated parmesan
+    amount: 5
+    unit: g
+    dish: J
+  - name: fresh parsley
+    amount: 1
+    unit: g
+    dish: J
+    prep: chopped fine
+steps:
+  - "Preheat the fish grill (or oven to 220°C). Bring sake to room temp if it's cold."
+  - "Whisk olive oil, garlic powder, and dried oregano together until uniform; brush over the cut faces of the garlic bread."
+  - "Toss the romaine, Italian dressing, and mikkusu cheese together in a bowl and set aside in the fridge — done with the salad."
+  - "Heat the Dutch oven over medium-high. Add butter, minced garlic, and red pepper flakes; cook 60 seconds until fragrant but not browned."
+  - "Pour in sake and soy sauce, bring to a simmer for 30 seconds, then add the asari clams and clamp the lid on. Steam 3–5 minutes, shaking the pot once or twice, until clams open. Discard any that don't open after 7 minutes."
+  - "Meanwhile, slide the garlic bread onto the fish grill and toast 6–8 minutes until golden and crisp at the edges. Pull it out, rub the cut faces with the halved raw garlic clove, then scatter parmesan and parsley over the top."
+  - "Pull the lid off the clams. Stir lemon zest and lemon juice through the broth; taste and adjust with a flake of salt if needed. Remove from heat — the Dutch oven is done."
+  - "Ladle the clams and broth into a deep bowl, scatter scallions over the top, and tuck the lemon wedges alongside. Plate the bread for dunking and the salad on its own plate. Eat immediately."
+---

--- a/astro_site/src/content/recipes/shrimp-pesto-stir-fry.md
+++ b/astro_site/src/content/recipes/shrimp-pesto-stir-fry.md
@@ -1,0 +1,97 @@
+---
+title: "Shrimp Pesto Stir Fry"
+date: 2025-09-29
+tags:
+  - shrimp
+  - quick
+  - fusion
+equipment:
+  - Wok
+  - Cutting board and knife
+  - Wooden spoon or spatula
+  - Small saucepan with tight lid (for rice)
+  - Mixing bowl
+ingredients:
+  - name: large shrimp
+    amount: 450
+    unit: g
+    dish: A
+    prep: peeled, deveined, patted dry
+  - name: salt
+    amount: 2
+    unit: g
+    dish: B
+  - name: black pepper
+    amount: 1
+    unit: g
+    dish: B
+  - name: olive oil for shrimp
+    amount: 15
+    unit: ml
+    dish: C
+  - name: olive oil for vegetables
+    amount: 15
+    unit: ml
+    dish: D
+  - name: bell pepper
+    amount: 1
+    unit: null
+    dish: E
+    dish_ml: 200
+    prep: sliced into thin strips
+  - name: zucchini
+    amount: 1
+    unit: null
+    dish: E
+    dish_ml: 200
+    prep: sliced into half-moons
+  - name: snap peas
+    amount: 100
+    unit: g
+    dish: F
+  - name: cherry tomatoes
+    amount: 150
+    unit: g
+    dish: F
+    prep: halved
+  - name: garlic cloves
+    amount: 3
+    unit: null
+    dish: F
+    prep: minced
+  - name: red pepper flakes
+    amount: 1
+    unit: g
+    dish: F
+  - name: basil pesto
+    amount: 80
+    unit: g
+    dish: G
+  - name: vegetable broth
+    amount: 30
+    unit: ml
+    dish: G
+  - name: fresh basil
+    amount: 5
+    unit: g
+    dish: H
+    prep: torn into rough pieces
+  - name: lemon
+    amount: 1
+    unit: null
+    dish: I
+    dish_ml: 60
+    prep: cut into 4 wedges
+  - name: cooked rice
+    amount: 400
+    unit: g
+    dish: J
+steps:
+  - "Start the rice in the saucepan: rinse, combine with water (~1.5x rice volume), bring to a boil, drop to lowest heat, lid on tight, cook 18 minutes, rest 10 minutes off heat. Season the shrimp with salt and pepper while the rice cooks."
+  - "Heat the wok over medium-high until just smoking. Add the shrimp oil, then the shrimp in a single layer. Cook 2 minutes per side until pink and just cooked through. Transfer to a bowl."
+  - "Add the vegetable oil to the wok. Add the bell pepper and zucchini and stir-fry 3–4 minutes until slightly tender but still crisp."
+  - "Add the snap peas, cherry tomatoes, garlic, and red pepper flakes. Stir-fry 2 minutes until the garlic is fragrant and the snap peas are bright green."
+  - "Whisk the pesto with the broth in a bowl to thin it. Pour over the vegetables and toss for 30 seconds to coat."
+  - "Return the shrimp to the wok and toss to combine. Heat through 60 seconds. Done with the wok."
+  - "Plate over rice, scatter torn basil over the top, and serve with lemon wedges."
+---

--- a/astro_site/src/content/recipes/single-serving-sweet-potato-casserole.md
+++ b/astro_site/src/content/recipes/single-serving-sweet-potato-casserole.md
@@ -1,0 +1,53 @@
+---
+title: "Single-Serving Sweet Potato Casserole"
+date: 2025-11-14
+tags:
+  - side
+  - american
+  - holiday
+attribution: "Single-serving riff on Boston Market style"
+equipment:
+  - Combo microwave/oven
+  - Fork
+  - Mixing bowl
+  - Small oven-safe ramekin
+  - Spoon
+ingredients:
+  - name: medium sweet potato
+    amount: 1
+    unit: null
+    dish: A
+    dish_ml: 250
+  - name: butter
+    amount: 14
+    unit: g
+    dish: B
+    prep: melted
+  - name: milk
+    amount: 22
+    unit: ml
+    dish: B
+  - name: maple syrup
+    amount: 22
+    unit: ml
+    dish: B
+  - name: salt
+    amount: 0.5
+    unit: g
+    dish: C
+  - name: cinnamon
+    amount: 0.25
+    unit: g
+    dish: C
+  - name: mini marshmallows
+    amount: 30
+    unit: g
+    dish: D
+steps:
+  - "Poke holes all over the sweet potato with a fork. Microwave at 600W for 6–7 minutes until a fork slides in with zero resistance. Let it cool 2 minutes so it's safe to handle."
+  - "Preheat the oven to 175°C."
+  - "Slice the sweet potato open and scoop the flesh into a mixing bowl. Mash with the melted butter, milk, and maple syrup until smooth. Stir in the salt and cinnamon — taste and adjust sweetness."
+  - "Spread the mash into the ramekin. The consistency should be thick like a pumpkin pie filling — spreadable but not runny."
+  - "Bake 25 minutes until the edges are bubbling and the top has firmed up."
+  - "Pull the ramekin, scatter the mini marshmallows across the top, and return to the oven for 8–12 minutes until golden and toasted. Done with the oven. Serve hot."
+---

--- a/astro_site/src/content/recipes/solo-buffalo-chicken-night.md
+++ b/astro_site/src/content/recipes/solo-buffalo-chicken-night.md
@@ -1,0 +1,106 @@
+---
+title: "Solo Buffalo Chicken Night"
+date: 2026-04-19
+tags:
+  - chicken
+  - american
+  - meal-prep
+equipment:
+  - Baking sheet
+  - Combo microwave/oven
+  - Two forks (for shredding)
+  - Mixing bowl for ranch
+  - Whisk
+  - Mixing bowl for chicken-sauce toss
+  - Mixing bowl for mash
+  - Potato masher or fork
+ingredients:
+  - name: boneless skinless chicken thighs
+    amount: 1000
+    unit: g
+    dish: A
+    prep: patted dry
+  - name: neutral oil
+    amount: 15
+    unit: ml
+    dish: B
+  - name: garlic powder
+    amount: 3
+    unit: g
+    dish: C
+  - name: onion powder
+    amount: 2
+    unit: g
+    dish: C
+  - name: paprika
+    amount: 2
+    unit: g
+    dish: C
+  - name: salt
+    amount: 5
+    unit: g
+    dish: C
+  - name: black pepper
+    amount: 1
+    unit: g
+    dish: C
+  - name: buffalo sauce
+    amount: 75
+    unit: ml
+    dish: D
+  - name: pre-cooked danshaku potato pack
+    amount: 350
+    unit: g
+    dish: E
+  - name: butter
+    amount: 30
+    unit: g
+    dish: F
+  - name: milk for mash
+    amount: 30
+    unit: ml
+    dish: F
+  - name: salt for mash
+    amount: 2
+    unit: g
+    dish: G
+  - name: plain yogurt
+    amount: 120
+    unit: ml
+    dish: H
+  - name: garlic powder for ranch
+    amount: 3
+    unit: g
+    dish: I
+  - name: onion powder for ranch
+    amount: 3
+    unit: g
+    dish: I
+  - name: dried dill
+    amount: 1
+    unit: g
+    dish: I
+  - name: dried parsley
+    amount: 1
+    unit: g
+    dish: I
+  - name: lemon juice
+    amount: 10
+    unit: ml
+    dish: J
+  - name: milk for thinning ranch
+    amount: 15
+    unit: ml
+    dish: J
+steps:
+  - "Preheat the oven to 200°C."
+  - "Pat the chicken dry, brush with the neutral oil, then rub the seasoning blend over both sides of every thigh."
+  - "Spread the thighs on the baking sheet in a single layer. Bake 25–30 minutes until juices run clear or internal temp hits 74°C."
+  - "Meanwhile, whisk the yogurt with the ranch spice mix and the lemon juice plus thinning milk until smooth. Taste, adjust salt, and refrigerate. Done with the ranch — fresh ranch is good, day-old ranch is great."
+  - "Pull the baking sheet from the oven and let the chicken rest uncovered for 8 minutes. The oven/microwave is now free."
+  - "Microwave the danshaku potato pack 2 minutes until hot through. Done with the oven/microwave."
+  - "While the potatoes heat, pull the chicken apart with two forks into rough shreds — uneven texture is good here."
+  - "Tip the hot potatoes into a bowl, add butter and milk, and mash until smooth. Season with salt and stop the moment it comes together."
+  - "Weigh out 250–300g of shredded chicken into a bowl, pour over buffalo sauce, and toss to coat. Refrigerate the remaining ~700g for leftovers — wraps, salads, or rice bowls all week."
+  - "Plate buffalo chicken alongside mash, with ranch for dipping. Crudités on the side if you want them."
+---

--- a/astro_site/src/content/recipes/taco-seasoning-blend.md
+++ b/astro_site/src/content/recipes/taco-seasoning-blend.md
@@ -1,0 +1,56 @@
+---
+title: "Taco Seasoning Blend"
+date: 2026-03-02
+tags:
+  - mexican
+  - spice-blend
+  - pantry
+equipment:
+  - Small bowl
+  - Whisk or fork
+  - Airtight container
+ingredients:
+  - name: chili powder
+    amount: 15
+    unit: g
+    dish: A
+  - name: ground cumin
+    amount: 10
+    unit: g
+    dish: A
+  - name: garlic powder
+    amount: 5
+    unit: g
+    dish: A
+  - name: onion powder
+    amount: 5
+    unit: g
+    dish: A
+  - name: smoked paprika
+    amount: 5
+    unit: g
+    dish: A
+  - name: salt
+    amount: 8
+    unit: g
+    dish: A
+  - name: black pepper
+    amount: 3
+    unit: g
+    dish: A
+  - name: dried oregano
+    amount: 3
+    unit: g
+    dish: A
+  - name: cayenne pepper
+    amount: 1.5
+    unit: g
+    dish: A
+  - name: cornstarch
+    amount: 5
+    unit: g
+    dish: A
+steps:
+  - "Whisk all ingredients together in a small bowl until uniformly blended — about 30 seconds of stirring."
+  - "Transfer to an airtight container. The blend keeps 6 months in the pantry."
+---

--- a/astro_site/src/layouts/Layout.astro
+++ b/astro_site/src/layouts/Layout.astro
@@ -58,6 +58,9 @@ const author = "Greg Thomas";
         <li title="Notes">
           <a href="/notes">Notes</a>
         </li>
+        <li title="Recipes">
+          <a href="/recipes">Recipes</a>
+        </li>
         <li title="Résumé">
           <a href="/documents/resume/">Résumé</a>
         </li>

--- a/astro_site/src/pages/recipes/[slug].astro
+++ b/astro_site/src/pages/recipes/[slug].astro
@@ -1,0 +1,131 @@
+---
+import { getCollection, type CollectionEntry } from 'astro:content';
+import { Image } from 'astro:assets';
+import Layout from '../../layouts/Layout.astro';
+
+export async function getStaticPaths() {
+  const recipes = await getCollection('recipes');
+  return recipes.map((recipe) => ({
+    params: { slug: recipe.slug },
+    props: { recipe },
+  }));
+}
+
+interface Props {
+  recipe: CollectionEntry<'recipes'>;
+}
+
+const { recipe } = Astro.props;
+const { Content } = await recipe.render();
+
+type Ingredient = CollectionEntry<'recipes'>['data']['ingredients'][number];
+
+const dishMap = new Map<string, Ingredient[]>();
+for (const ingredient of recipe.data.ingredients) {
+  if (!dishMap.has(ingredient.dish)) {
+    dishMap.set(ingredient.dish, []);
+  }
+  dishMap.get(ingredient.dish)!.push(ingredient);
+}
+
+const dishes = Array.from(dishMap.entries()).sort(([a], [b]) => a.localeCompare(b));
+
+function dishVolumeMl(ingredients: Ingredient[]): number {
+  let total = 0;
+  for (const ing of ingredients) {
+    if (ing.unit === 'ml' || ing.unit === 'g') {
+      total += ing.amount;
+    } else if (ing.dish_ml != null) {
+      total += ing.dish_ml;
+    }
+  }
+  return total;
+}
+---
+
+<Layout title={recipe.data.title}>
+  <article class="recipe">
+    <h1>{recipe.data.title}</h1>
+
+    {recipe.data.featuredImage && (
+      <div class="featured-image">
+        <Image
+          src={recipe.data.featuredImage}
+          alt={`Featured image for ${recipe.data.title}`}
+          width={800}
+          height={500}
+          loading="eager"
+        />
+      </div>
+    )}
+
+    {recipe.data.attribution && (
+      <p class="attribution"><em>{recipe.data.attribution}</em></p>
+    )}
+
+    {recipe.data.tags && recipe.data.tags.length > 0 && (
+      <ul class="tags" style="list-style: none; padding: 0; display: flex; gap: 0.5rem; flex-wrap: wrap;">
+        {recipe.data.tags.map(tag => <li><small>{tag}</small></li>)}
+      </ul>
+    )}
+
+    <section class="equipment">
+      <h2>Equipment</h2>
+      <ul>
+        {recipe.data.equipment.map(item => <li>{item}</li>)}
+      </ul>
+    </section>
+
+    <section class="ingredients">
+      <h2>Ingredients</h2>
+      {dishes.map(([dish, ingredients]) => {
+        const flagged = dish.length === 1 && dishVolumeMl(ingredients) >= 90;
+        const label = dish.length === 1 ? `Dish ${dish}` : dish;
+        return (
+          <div class="dish-group">
+            <h3>{label}{flagged && ' *'}</h3>
+            <ul>
+              {ingredients.map((ing, i) => {
+                const id = `dish-${dish}-${i}`;
+                return (
+                  <li>
+                    <input type="checkbox" id={id} />
+                    <label for={id}>
+                      {ing.amount}{ing.unit ? ` ${ing.unit}` : ''} {ing.name}{ing.prep ? `, ${ing.prep}` : ''}
+                    </label>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        );
+      })}
+      {dishes.some(([, ingredients]) => dishVolumeMl(ingredients) >= 90) && (
+        <p><small>* larger than my standard 90ml prep dish</small></p>
+      )}
+    </section>
+
+    <section class="steps">
+      <h2>Steps</h2>
+      {recipe.data.steps.length > 0 ? (
+        <ol>
+          {recipe.data.steps.map((step, i) => (
+            <li>
+              <input type="checkbox" id={`step-${i}`} />
+              <label for={`step-${i}`}>{step}</label>
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <Content />
+      )}
+    </section>
+  </article>
+</Layout>
+
+<style>
+  input[type="checkbox"]:checked + label {
+    color: grey;
+    text-decoration: line-through;
+  }
+</style>

--- a/astro_site/src/pages/recipes/index.astro
+++ b/astro_site/src/pages/recipes/index.astro
@@ -1,0 +1,66 @@
+---
+import { getCollection } from 'astro:content';
+import { Image } from 'astro:assets';
+import Layout from '../../layouts/Layout.astro';
+
+const recipes = await getCollection('recipes');
+recipes.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+---
+
+<Layout title="Recipes">
+  <h1>Recipes</h1>
+
+  <ul class="h-feed list">
+    {recipes.map((recipe, index) => (
+      <li>
+        <article class="h-entry">
+          <header
+            style="
+              display: flex;
+              flex-direction: column;
+              align-items: flex-start;
+              justify-content: center;
+              align-self: flex-start;
+              font-size: small;
+            "
+          >
+            <a
+              class="p-name"
+              href={`/recipes/${recipe.slug}/`}
+              style="font-size: 1.5rem;"
+            >
+              {recipe.data.title}
+            </a>
+            <small>
+              <time
+                datetime={recipe.data.date.toISOString()}
+                class="dt-published"
+              >
+                {recipe.data.date.toLocaleDateString('en-US', {
+                  year: 'numeric',
+                  month: 'short',
+                  day: 'numeric'
+                })}
+              </time>
+            </small>
+            {recipe.data.tags && recipe.data.tags.length > 0 && (
+              <small>{recipe.data.tags.join(', ')}</small>
+            )}
+          </header>
+          {recipe.data.featuredImage && (
+            <div class="featured-image">
+              <Image
+                src={recipe.data.featuredImage}
+                alt={`Featured image for ${recipe.data.title}`}
+                width={600}
+                height={400}
+                loading="lazy"
+              />
+            </div>
+          )}
+        </article>
+        {index < recipes.length - 1 && <hr />}
+      </li>
+    ))}
+  </ul>
+</Layout>


### PR DESCRIPTION
## Summary

- Adds a `recipes` content collection to `config.ts` with a structured Zod schema: title, date, tags, featuredImage (mirrors notes pipeline), attribution, equipment, ingredients (with dish grouping, `dish_ml` for volume estimation, and prep notes), and steps
- `/recipes` listing page — reverse chronological, consistent with Posts style
- `/recipes/[slug]` detail page — equipment list → ingredients grouped by mise en place dish → steps, all in that order
- "Recipes" nav link added to shared Layout between Notes and Résumé
- 21 recipe files in `src/content/recipes/`

## Details a reviewer should know

**Ingredient dish grouping & 90ml flag** — Ingredients are assigned a `dish` label (single letter like `A`, `B`, or a descriptive string like `"In Their Cans"`). The template groups them and flags single-letter dishes whose total estimated volume ≥ 90ml with a `*` and a footnote. Volume is estimated as 1g ≈ 1ml; countable items can opt in via `dish_ml`. Descriptive dish labels are never flagged since the label already implies a non-standard container.

**Checkboxes** — Both ingredient lines and steps render with `<input type="checkbox">` + `<label>` pairs. Checking one strikes it through in grey via CSS only — no JavaScript anywhere in the rendered output.

**Steps as structured data** — Steps live in the frontmatter `steps` array rather than the markdown body. Recipes without a `steps` field (field defaults to `[]`) fall back to rendering `<Content />` so nothing breaks, but the checkboxes only appear for structured steps.

## Test plan

- [ ] `npx astro build` completes without errors
- [ ] `/recipes` lists all 21 recipes in reverse chronological order
- [ ] `/recipes/[slug]` renders equipment, grouped ingredients with flagging, and checkable steps
- [ ] Checking an ingredient or step strikes it through with no JS
- [ ] Recipes nav link appears and resolves
- [ ] No `<script>` tags in rendered recipe pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)